### PR TITLE
typescript-sdk-odc can support both OD and ODSP

### DIFF
--- a/samples/file-picking/sdk-domevents/src/index.ts
+++ b/samples/file-picking/sdk-domevents/src/index.ts
@@ -9,7 +9,7 @@ import { combine } from "./utils.js";
 
 export * from "./types.js";
 
-type TokenFactory = (command: IAuthenticateCommand) => Promise<string>;
+export type TokenFactory = (command: IAuthenticateCommand) => Promise<string>;
 
 interface PickerChangeEvent extends Event {
     detail: IPickData;
@@ -29,16 +29,16 @@ type PickerWindow = {
     removeEventListener<K extends keyof PickerWindowEventMap>(type: K, listener: (this: Window, ev: PickerWindowEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
 }
 
-interface BasePickerInit {
+export interface BasePickerInit {
     tokenFactory: TokenFactory,
     options: IFilePickerOptions,
 }
 
-interface OneDriveConsumerInit extends BasePickerInit {
+export interface OneDriveConsumerInit extends BasePickerInit {
     type: "Consumer",
 }
 
-interface ODSPInit extends BasePickerInit {
+export interface ODSPInit extends BasePickerInit {
     type: "ODSP",
     baseUrl: string,
 }

--- a/samples/file-picking/typescript-sdk-odc/src/main.ts
+++ b/samples/file-picking/typescript-sdk-odc/src/main.ts
@@ -3,39 +3,32 @@ import {
     IFilePickerOptions,
     INotificationData,
     IPickData,
+    OneDriveConsumerInit,
+    ODSPInit,
+    IAuthenticateCommand,
 } from "@pnp/picker-sdk";
 
-import { getTokenWithScopes } from "./auth";
+import { getToken } from "./auth";
 
 document.onreadystatechange = () => {
     if (document.readyState === "interactive") {
         const button: HTMLButtonElement = <any>document.getElementById("launchpicker");
-        button.onclick = createWindow;
+        button.onclick = launchOneDrivePicker;
     }
 };
 
-const options: IFilePickerOptions = {
-    sdk: "8.0",
-    entry: {
-        oneDrive: {}
-    },
-    authentication: {},
-    messaging: {
-        origin: "http://localhost:3000",
-        channelId: "27"
-    },
-};
+const sharepoint_baseUrl = "https://tenant-my.sharepoint.com";
 
-async function createWindow(e) {
+async function launchOneDrivePicker(e) {
 
     e.preventDefault();
 
+    const accountType: "Consumer" | "ODSP" = "Consumer";
+
+    const init: OneDriveConsumerInit | ODSPInit = getOneDriveInit(accountType);
+
     // setup the picker with the desired behaviors
-    const picker = await Picker(window.open("", "Picker", "width=800,height=600"), {
-        type: "Consumer",
-        options,
-        tokenFactory: () => getTokenWithScopes(["OneDrive.ReadWrite"]),
-    });
+    const picker = await Picker(window.open("", "Picker", "width=800,height=600"), init);
 
     picker.addEventListener("pickernotifiation", (e: CustomEvent<INotificationData>) => {
 
@@ -47,3 +40,83 @@ async function createWindow(e) {
         document.getElementById("pickerResults").innerHTML = `<pre>${JSON.stringify(e.detail, null, 2)}</pre>`
     });
 }
+function getFilePickerOptions(accountType: string): IFilePickerOptions {
+    if (accountType == "Consumer") {
+        return {
+            sdk: "8.0",
+            entry: {
+                oneDrive: {}
+            },
+            authentication: {},
+            messaging: {
+                origin: "http://localhost:3000",
+                channelId: "27"
+            },
+        };
+
+    } else {
+        return {
+            sdk: "8.0",
+            entry: {
+                sharePoint: {
+                    byPath: {
+                        web: sharepoint_baseUrl,
+                        list: "SitePages"
+                    }
+                }
+            },
+            authentication: {},
+            messaging: {
+                origin: "http://localhost:3000",
+                channelId: "27"
+            },
+            typesAndSources: {
+                mode: "all",
+                filters: [".aspx"],
+                pivots: {
+                    recent: false,
+                    oneDrive: false
+                }
+            }
+        };
+    }
+}
+
+function getOneDriveInit(accountType: string): OneDriveConsumerInit | ODSPInit {
+
+    const options: IFilePickerOptions = getFilePickerOptions(accountType);
+    
+    let authCmd : IAuthenticateCommand = null;
+
+    if (accountType == "Consumer") {
+        authCmd = {
+            command: "authenticate",
+            type: "Graph",
+            resource: "",
+        }
+        const init: OneDriveConsumerInit = {
+            type: "Consumer",
+            options,
+            tokenFactory: () => getToken(authCmd),
+        };
+
+        return init;
+
+    } else {
+
+        authCmd = {
+            command: "authenticate",
+            type: "SharePoint",
+            resource: sharepoint_baseUrl,
+        }
+
+        const init: ODSPInit = {
+            type: "ODSP",
+            baseUrl: sharepoint_baseUrl,
+            options,
+            tokenFactory: () => getToken(authCmd),
+        };
+        return init;
+    }
+}
+


### PR DESCRIPTION
Current typescript-sdk-odc sample works with one drive personal. Updated code such that based on accountType, same code could be re-used to even connect to ODSP. Also made ClientAuthority url dynamically chosen based on ODSP or OD.
This code could server a one stop destination for developers looking to integrate one drive (OD and ODSP) into their apps.